### PR TITLE
kernel-modules-headers: Remove x86 binaries to pass QA checks

### DIFF
--- a/layers/meta-resin-asus-tinker-board/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bbappend
+++ b/layers/meta-resin-asus-tinker-board/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bbappend
@@ -1,0 +1,7 @@
+do_install_append () {
+    # Remove precompiled x86 binaries inherited from the kernel git tree.
+    # These are still part of the tarball. But removed from the package
+    # as we use the package infrastructure for QA checks
+    rm -f "${D}/usr/src/kernel-hdrs/scripts/mkkrnlimg"
+    rm -f "${D}/usr/src/kernel-hdrs/scripts/resource_tool"
+}


### PR DESCRIPTION
merge after https://github.com/balena-os/meta-balena/pull/1320 is merged in meta-balena