### PR TITLE
u-boot: Enable CONFIG_CMD_SETEXPR for asus-tinker-board

### DIFF
--- a/layers/meta-resin-asus-tinker-board/recipes-bsp/u-boot/patches/0002-asus-tinker-board-Enable-CONFIG_CMD_SETEXPR.patch
+++ b/layers/meta-resin-asus-tinker-board/recipes-bsp/u-boot/patches/0002-asus-tinker-board-Enable-CONFIG_CMD_SETEXPR.patch
@@ -1,0 +1,37 @@
+From 4f69a9aa5659ec9534f5c522d128a7fe5679aa56 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Tue, 29 Jan 2019 11:13:14 +0100
+Subject: [PATCH] asus-tinker-board: Enable CONFIG_CMD_SETEXPR
+
+This is necessary for integration with the
+BalenaOS v2.30 release
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ configs/tinker-rk3288_defconfig | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configs/tinker-rk3288_defconfig b/configs/tinker-rk3288_defconfig
+index 89394f5..0c62cce 100755
+--- a/configs/tinker-rk3288_defconfig
++++ b/configs/tinker-rk3288_defconfig
+@@ -21,7 +21,7 @@ CONFIG_CMD_SPI=y
+ CONFIG_CMD_I2C=y
+ CONFIG_CMD_USB=y
+ CONFIG_CMD_GPIO=y
+-# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_SETEXPR=y
+ CONFIG_CMD_CACHE=y
+ CONFIG_CMD_TIME=y
+ CONFIG_CMD_PMIC=y
+@@ -71,4 +71,4 @@ CONFIG_USE_TINY_PRINTF=y
+ CONFIG_CMD_DHRYSTONE=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
+ CONFIG_ERRNO_STR=y
+-CONFIG_BOOTDELAY=1
+\ No newline at end of file
++CONFIG_BOOTDELAY=1
+-- 
+2.7.4
+

--- a/layers/meta-resin-asus-tinker-board/recipes-bsp/u-boot/u-boot-tinker-board.bbappend
+++ b/layers/meta-resin-asus-tinker-board/recipes-bsp/u-boot/u-boot-tinker-board.bbappend
@@ -3,4 +3,7 @@ UBOOT_KCONFIG_SUPPORT = "1"
 inherit resin-u-boot
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
-SRC_URI_append = " file://0001-Add-Resin-specific-boot-command.patch"
+SRC_URI_append = " \
+	file://0001-Add-Resin-specific-boot-command.patch \
+	file://0002-asus-tinker-board-Enable-CONFIG_CMD_SETEXPR.patch \
+"


### PR DESCRIPTION
This applies to both asus-tinker-board and
asus-tinker-board-s machines

Fixes https://github.com/balena-os/balena-asus-tinker-board/issues/22