### PR TITLE
Enable framebruffer console rotation in the kernel

### DIFF
--- a/layers/meta-balena-asus-tinker-board/recipes-kernel/linux/linux-tinker-board.bbappend
+++ b/layers/meta-balena-asus-tinker-board/recipes-kernel/linux/linux-tinker-board.bbappend
@@ -1,1 +1,6 @@
 inherit kernel-resin
+
+RESIN_CONFIGS_append = " fbcon"
+RESIN_CONFIGS[fbcon] = " \
+    CONFIG_FRAMEBUFFER_CONSOLE_ROTATION=y \
+    "


### PR DESCRIPTION
It can be controlled with for example:
```
echo 1 > /sys/devices/virtual/graphics/fbcon/rotate_all
```

Changelog-entry: Enable framebruffer console rotation in the kernel
Signed-off-by: Gergely Imreh <gergely@balena.io>